### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-papa-promise",
   "version": "0.0.4",
-  "description": "This module provides an AngularJS service wrapper for the PapaParse (http://papaparse.com/) CSV parsing library so it can be injected via dependency injection. It uses promises instead of the default callback mechanism.",
+  "description": "This module provides an AngularJS promise based service wrapper for the PapaParse (http://papaparse.com/) CSV parsing library.",
   "main": "dist/angular-papa-promise.js",
   "authors": [
     "Oliver Färber"


### PR DESCRIPTION
Fix description length to avoid bower warning

bower angular-papa-promise#\*     invalid-meta The "description" is too long, the limit is 140 characters
